### PR TITLE
Add go modules

### DIFF
--- a/cmd/revgrep/main.go
+++ b/cmd/revgrep/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bradleyfalzon/revgrep"
+	"github.com/golangci/revgrep"
 )
 
 func main() {

--- a/cmd/revgrep/main.go
+++ b/cmd/revgrep/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/golangci/revgrep"
+	"github.com/corverroos/revgrep"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/golangci/revgrep
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/golangci/revgrep
+module github.com/corverroos/revgrep
 
 go 1.13


### PR DESCRIPTION
We would like to run the revgrep binary for your fork since you fixed the `ls-files` missing `--exclude-standard` issue. 

Currently the command points to the original repo `bradleyfalzon` which bypasses the fix.