### PR TITLE
Add go modules

### DIFF
--- a/cmd/revgrep/main.go
+++ b/cmd/revgrep/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bradleyfalzon/revgrep"
+	"github.com/golangci/revgrep"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/golangci/revgrep
+
+go 1.13


### PR DESCRIPTION
We would like to use your fork's `revgrep` command since it fixes the `git ls-files` missing `--exclude-standard` issue. But the command still points to the upstream.

