### PR TITLE
Use bufio.Reader to handle large git histories

### DIFF
--- a/cmd/revgrep/main.go
+++ b/cmd/revgrep/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bradleyfalzon/revgrep"
+	"github.com/golangci/revgrep"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/golangci/revgrep
+
+go 1.13

--- a/revgrep.go
+++ b/revgrep.go
@@ -281,24 +281,12 @@ func (c Checker) linesChanged() map[string][]pos {
 
 	scanner := bufio.NewReader(c.Patch)
 	var scanErr error
-Loop:
 	for {
 		lineB, isPrefix, err := scanner.ReadLine()
 		if isPrefix {
-			// If a single line overflowed the buffer, keep building it up. This
-			// leaves the possibility of a DOS attack by a user creating a git commit
-			// with a line so large it OOMs the process calling golangci-lint.
-			for {
-				lineB2, isPrefix2, err2 := scanner.ReadLine()
-				if err2 != nil {
-					scanErr = err2
-					break Loop
-				}
-				lineB = append(lineB, lineB2...)
-				if isPrefix2 {
-					continue
-				}
-			}
+			// If a single line overflowed the buffer, don't bother processing it as
+			// it's likey part of a file and not relevant to the patch.
+			continue
 		}
 		if err != nil {
 			scanErr = err


### PR DESCRIPTION
Processing large git repositories with `revgrep` may result in failed
parsing due to long lines. For example:

```
$ golint ./... |& revgrep abcd1234
reading standard input: bufio.Scanner: token too long
```

From the Go documentation for Scanner:
```
Programs that need more control over error handling or large tokens, or
must run sequential scans on a reader, should use bufio.Reader instead.
```

This updates `revgrep`'s git reader to use `bufio.Reader` to avoid this
issue. For example:
```
$ golint ./... |& revgrep abcd1234
mycode.go:8:2: a blank import should be only in a main or test package,
or have a comment justifying it
```

I don't have a reproducible test case as this happened in non-public code,
but can try to put one together.

The tests are failing for me on `TestChangesWriter` for this PR, but the same
occur encountered on `master`.