### PR TITLE
fix: force use of default diff

### DIFF
--- a/revgrep.go
+++ b/revgrep.go
@@ -366,7 +366,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 	}
 
 	if revisionFrom != "" {
-		cmd := exec.Command("git", "diff", "--color=never", "--relative", revisionFrom)
+		cmd := exec.Command("git", "diff", "--color=never", "--no-ext-diff", "--default-prefix", "--relative", revisionFrom)
 		if revisionTo != "" {
 			cmd.Args = append(cmd.Args, revisionTo)
 		}
@@ -384,8 +384,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 	}
 
 	// make a patch for unstaged changes
-	// use --no-prefix to remove b/ given: +++ b/main.go
-	cmd := exec.Command("git", "diff", "--color=never", "--relative", "--")
+	cmd := exec.Command("git", "diff", "--color=never", "--no-ext-diff", "--default-prefix", "--relative", "--")
 	cmd.Stdout = &patch
 	if err := cmd.Run(); err != nil {
 		return nil, nil, fmt.Errorf("error executing git diff: %w", err)
@@ -400,7 +399,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 
 	// check for changes in recent commit
 
-	cmd = exec.Command("git", "diff", "--color=never", "--relative", "HEAD~", "--")
+	cmd = exec.Command("git", "diff", "--color=never", "--no-ext-diff", "--default-prefix", "--relative", "HEAD~", "--")
 	cmd.Stdout = &patch
 	if err := cmd.Run(); err != nil {
 		return nil, nil, fmt.Errorf("error executing git diff HEAD~: %w", err)


### PR DESCRIPTION
This fix resolves issues that arise when the user has configured an alternative diff provider through diff.external. It also ensures that the default prefix setting is consistently used, allowing `revgrep` to operate correctly regardless of user settings.

https://github.com/golangci/golangci-lint/issues/4060

https://git-scm.com/docs/git-diff